### PR TITLE
API 요청 로직 구현

### DIFF
--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -1,0 +1,31 @@
+import axios from 'axios';
+
+const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/auth';
+
+const instance = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+axios.interceptors.request.use(
+  function (config) {
+    return config;
+  },
+  function (error) {
+    return error;
+  }
+);
+
+export const signIn = ({ email, password }) =>
+  instance.post('/signin', {
+    email,
+    password,
+  });
+
+export const signUp = ({ email, password }) =>
+  instance.post('/signup', {
+    email,
+    password,
+  });

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -41,6 +41,6 @@ instance.interceptors.response.use(
     if (!data.message) {
       return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));
     }
-    return Promise.reject(data.message);
+    return Promise.reject(new Error(data.message));
   }
 );

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
-const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/auth';
-
 const instance = axios.create({
-  baseURL: BASE_URL,
+  baseURL: `${process.env.REACT_APP_API_END_POINT}/auth`,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -39,6 +37,7 @@ instance.interceptors.response.use(
   (error) => {
     const { data } = error.response;
     if (!data.message) {
+      console.log(error);
       return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));
     }
     return Promise.reject(new Error(data.message));

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -9,23 +9,38 @@ const instance = axios.create({
   },
 });
 
-axios.interceptors.request.use(
-  function (config) {
-    return config;
+export const signIn = async ({ email, password }) => {
+  const response = await instance.post('/signin', {
+    email,
+    password,
+  });
+
+  return {
+    access_token: response.data.access_token,
+    message: '로그인에 성공했습니다.',
+  };
+};
+
+export const signUp = async ({ email, password }) => {
+  await instance.post('/signup', {
+    email,
+    password,
+  });
+
+  return {
+    message: '회원가입에 성공했습니다.',
+  };
+};
+
+instance.interceptors.response.use(
+  function (response) {
+    return response;
   },
   function (error) {
-    return error;
+    const { data } = error.response;
+    if (!data.message) {
+      return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));
+    }
+    return Promise.reject(data.message);
   }
 );
-
-export const signIn = ({ email, password }) =>
-  instance.post('/signin', {
-    email,
-    password,
-  });
-
-export const signUp = ({ email, password }) =>
-  instance.post('/signup', {
-    email,
-    password,
-  });

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -33,10 +33,10 @@ export const signUp = async ({ email, password }) => {
 };
 
 instance.interceptors.response.use(
-  function (response) {
+  (response) => {
     return response;
   },
-  function (error) {
+  (error) => {
     const { data } = error.response;
     if (!data.message) {
       return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));

--- a/src/apis/todo.js
+++ b/src/apis/todo.js
@@ -1,0 +1,71 @@
+import axios from 'axios';
+
+const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/todos';
+
+const instance = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export const getTodoList = async () => {
+  const response = await instance.get('/');
+
+  return {
+    todoList: response.data,
+    message: '성공적으로 조회했습니다.',
+  };
+};
+
+export const createTodo = async (data) => {
+  await instance.post('/', { todo: data });
+
+  return {
+    message: '성공적으로 추가했습니다.',
+  };
+};
+
+export const updateTodo = async (id, { todo, isCompleted }) => {
+  await instance.put(`/${id}`, {
+    todo,
+    isCompleted,
+  });
+
+  return {
+    message: '성공적으로 수정했습니다.',
+  };
+};
+
+export const deleteTodo = async (id) => {
+  await instance.delete(`/${id}`);
+
+  return {
+    message: '성공적으로 삭제했습니다.',
+  };
+};
+
+instance.interceptors.request.use(
+  function (config) {
+    const accessToken = localStorage.getItem('access_token');
+    const newConfig = config;
+    newConfig.headers.Authorization = `Bearer ${accessToken}`;
+    return newConfig;
+  },
+  function (error) {
+    return Promise.reject(error);
+  }
+);
+
+instance.interceptors.response.use(
+  function (response) {
+    return response;
+  },
+  function (error) {
+    const { data } = error.response;
+    if (!data.message) {
+      return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));
+    }
+    return Promise.reject(data.message);
+  }
+);

--- a/src/apis/todo.js
+++ b/src/apis/todo.js
@@ -49,7 +49,9 @@ instance.interceptors.request.use(
   (config) => {
     const accessToken = localStorage.getItem('access_token');
     const newConfig = config;
-    newConfig.headers.Authorization = `Bearer ${accessToken}`;
+    if (accessToken === undefined) {
+      newConfig.headers.Authorization = `Bearer ${accessToken}`;
+    }
     return newConfig;
   },
   (error) => {

--- a/src/apis/todo.js
+++ b/src/apis/todo.js
@@ -66,6 +66,6 @@ instance.interceptors.response.use(
     if (!data.message) {
       return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));
     }
-    return Promise.reject(data.message);
+    return Promise.reject(new Error(data.message));
   }
 );

--- a/src/apis/todo.js
+++ b/src/apis/todo.js
@@ -47,7 +47,7 @@ instance.interceptors.request.use(
   (config) => {
     const accessToken = localStorage.getItem('access_token');
     const newConfig = config;
-    if (accessToken === undefined) {
+    if (accessToken !== undefined) {
       newConfig.headers.Authorization = `Bearer ${accessToken}`;
     }
     return newConfig;

--- a/src/apis/todo.js
+++ b/src/apis/todo.js
@@ -46,22 +46,22 @@ export const deleteTodo = async (id) => {
 };
 
 instance.interceptors.request.use(
-  function (config) {
+  (config) => {
     const accessToken = localStorage.getItem('access_token');
     const newConfig = config;
     newConfig.headers.Authorization = `Bearer ${accessToken}`;
     return newConfig;
   },
-  function (error) {
+  (error) => {
     return Promise.reject(error);
   }
 );
 
 instance.interceptors.response.use(
-  function (response) {
+  (response) => {
     return response;
   },
-  function (error) {
+  (error) => {
     const { data } = error.response;
     if (!data.message) {
       return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));

--- a/src/apis/todo.js
+++ b/src/apis/todo.js
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
-const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/todos';
-
 const instance = axios.create({
-  baseURL: BASE_URL,
+  baseURL: `${process.env.REACT_APP_API_END_POINT}/todos`,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## 개요
서버 API 요청과 응답을 처리하기 위한 로직을 구현했어요.
 
사전에 진행한 코드리뷰를 바탕으로 다수가 공감한 좋은 부분을 뽑아오려고 노력했습니다!

또한 제가 작업한 api 관련 피드백에서, 공통 로직부분의 추상화가 잘 되어있지 않고, 또 message 속성으로만 error인지를 판별하는 것에 대해
코드품질이 좋지않다고 생각한 것에 대해 개선했어요.

## 작업내용
- api 디렉토리 분리
   도메인 기준으로 api 모듈을 분리하고 이들을 위한 api 디렉토리를 만들어줬어요
- axios 사용
   fetch API 대신 인스턴스 설정, 에러 커스텀 등 통신에 유용한 기능들이 많이 제공되는 axios를 선택했어요
- instance 생성
   authorization, content-type 헤더를 설정해서 반복된 코드를 줄였어요.
- Interceptor 활용
  - 실제 요청 전송되기 전에 access_token를 헤더에 추가되도록 했어요.
  - 일관된 에러 핸들링
     요청이 성공하면, 응답 data와 성공 message가 전달되고
     실패면 에러 객체에 message를 담아 전달되도록 개선했어요.
     따라서 모든 api 요청에 대한 에러를 표시하려면 `error.message`를 출력하면 됩니다.
- 고민 내용
   - 만약 access_token 유효성 검사를 컴포넌트 단에서 한다면, interceptor 사용하지않고 instance 헤더에 설정하는 게 낫지 않을까 싶어요
      코드 보시면 아시겠지만 interceptor를 통해 헤더 설정하는게 의미없어 보이네요..!

## 관련 이슈
- close #8 
